### PR TITLE
docs(security): add token hygiene policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,8 @@
+# Security Policy
+
+## Personal Access Tokens
+
+- **Scope**: `repo`, `workflow`, `write:packages`
+- **Rotation**: Every 90 days
+- **Storage**: Never committed; stored via Git credential helper
+- **Usage**: Only for CI/CD authentication; never used interactively


### PR DESCRIPTION
This PR adds a security policy document that outlines the best practices for handling personal access tokens.